### PR TITLE
travis: Use sudo-less build, uncache node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 python:
   - "3.4.3"
@@ -16,5 +17,4 @@ script:
 cache:
   directories:
     - dashboard/vendor/bundle
-    - dashboard/node_modules
     - ${HOME}/.cache/pip


### PR DESCRIPTION
Without versions of modules pinned down in package.json, caching node_modules can subtly create differences in builds between Travis and npm install.
